### PR TITLE
Create Issue templates for Upgrade regressisons

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,30 @@
+blank_issues_enabled: false
+contact_links:
+    - name: 🏠 Main React Native Repository
+      url: https://github.com/facebook/react-native
+      about: |
+        Looking for the React Native repository itself? Follow this link.
+    - name: ❓ React Native Releases FAQ
+      url: https://reactnative.dev/contributing/release-faq
+      about: |
+        Any questions about the release? Check our FAQ on the website.
+    - name: 🚀 Expo Issue
+      url: https://github.com/expo/expo/issues/new
+      about: |
+        If you're using Expo in your project, please report the issue first in the Expo issue tracker.
+    - name: 📃 Documentation Issue
+      url: https://github.com/facebook/react-native-website/issues
+      about: Please report documentation issues in the React Native website repository.
+    - name: 📦 Metro Issue
+      url: https://github.com/facebook/metro/issues/new
+      about: |
+        If you've encountered a module resolution problem, e.g. "Error: Unable to resolve module ...", or something else that might be related to Metro, please open an issue in the Metro repo instead.
+    - name: 🤔 Questions and Help
+      url: https://reactnative.dev/help
+      about: Looking for help with your app? Please refer to the React Native community's support resources.
+    - name: 💫 New Architecture - Questions & Technical Deep dive insights
+      url: https://github.com/reactwg/react-native-new-architecture
+      about: Questions and doubts related to technical questions for the New Architecture should be directed to the Working Group. Instructions on how to join are available in the README.
+    - name: 🚀 Discussions and Proposals
+      url: https://github.com/react-native-community/discussions-and-proposals
+      about: Discuss the future of React Native in the React Native community's discussions and proposals repository.

--- a/.github/ISSUE_TEMPLATE/pick_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/pick_request_form.yml
@@ -1,0 +1,34 @@
+name: 🍒⛏️ Cherry-pick Request
+description: Do you need a commit cherry-picked into the release branch? Start here.
+labels: ["Type: Pick Request"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Cherry-pick Request
+        Do you want to request a pick into one or multiple release branches? Please refer to the [Support table](https://github.com/reactwg/react-native-releases?tab=readme-ov-file#which-versions-are-currently-supported) to ensure all versions you are requesting a pick for are in a valid release window.
+  - type: input
+    id: target-branch
+    attributes:
+      label: Target Branch(es)
+      description: Please input which Release Branch(es) need this pick, eg `0.74, 0.73`. See our [Releases Support Policy](https://github.com/reactwg/react-native-releases#releases-support-policy).
+      placeholder: 0.74
+    validations:
+      required: true
+  - type: input
+    id: commit-link
+    attributes:
+      label: Link to commit or PR to be picked
+      description: Provide the commit or Pull Request that needs to be picked. We prefer to merge picks that are already in `main`, exceptions apply only when this is not possible due to merge conflicts.
+      placeholder: https://github.com/facebook/react-native/pulls/<pull-request-id> or https://github.com/facebook/react-native/commit/<commit-hash>
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe why you believe this change needs to be picked. The Release Crew will evaluate the pick request, generally only accepting hotfixes for breaking issues.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/test_report.yml
+++ b/.github/ISSUE_TEMPLATE/test_report.yml
@@ -1,0 +1,54 @@
+name: 📝 Test Report
+description: Are you testing the release and are submitting a test report? Start here!
+labels: ["Type: Test Report"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Test Report
+        Test reports are used to evaluate new React Native releases across a number of test configurations. They serve as logged summaries, jumping off points for regression investigations, and generally as a structured validation. Generally, these Test Reports are filled out by Release Crew members. Note: This is not the correct form to report generic issues or upgrade regressions. Start at https://github.com/facebook/react-native/issues/new/choose for those.
+  - type: input
+    id: release-branch
+    attributes:
+      label: For which release is this report?
+      description: If you are testing multiple releases, please file separate Test Report issues for each of them for easier handling.
+      placeholder: 0.74
+    validations:
+      required: true
+  - type: input
+    id: exact-version
+    attributes:
+      label: What specific version of React Native did you test?
+      description: Please provide the exact React Native version you used for this test
+      placeholder: 0.74-rc0
+    validations:
+      required: true
+  - type: textarea
+    id: system-configuration
+    attributes:
+      label: Under what system configuration was the test run?
+      description: Please provide the host platform + version, as well as the versions of tools such as Xcode. You can easily generate a standardised version of this information by running `npx react-native@<exact-version< info`.
+      placeholder: cd your/project/root && npx react-native@<exact-version> info
+    validations:
+      required: true
+  - type: textarea
+    id: configurations-covered
+    attributes:
+      label: Tested configurations
+      value: |
+        RNTester + iOS + Hermes: ✅/⚠️/❌
+        RNTester + iOS + JSC:  ✅/⚠️/❌
+        RNTester + Android + Hermes: ✅/⚠️/❌
+        RNTester + Android + JSC: ✅/⚠️/❌
+        RNTestProject + iOS + Hermes: ✅/⚠️/❌
+        RNTestProject + iOS + JSC: ✅/⚠️/❌
+        RNTestProject + Android + Hermes: ✅/⚠️/❌
+        RNTestProject + Android + JSC: ✅/⚠️/❌
+  - type: textarea
+    id: notes
+    attributes:
+      label: Testing Notes
+      description: Please provide any notable observations, issues encountered or fixes for regressions validated.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/upgrade_regression_form.yml
+++ b/.github/ISSUE_TEMPLATE/upgrade_regression_form.yml
@@ -1,0 +1,133 @@
+name: ⬆️ Upgrade - Build Regression
+description: If you are upgrading to a new React Native version (stable or pre-release) and encounter a build regression.
+labels: ["Type: Upgrade Issue"]
+
+body:
+  - type: markdown
+    attributes:
+      value: "## Upgrade Issues"
+  - type: markdown
+    attributes:
+      value: |
+        Please use this form to file an issue if you have upgraded or are upgrading to [latest stable release](https://github.com/facebook/react-native/releases/latest) and have experienced a regression (something that used to work in previous version).
+
+        If you're **NOT** upgrading the React Native version, please use this [other bug type](https://github.com/facebook/react-native/issues/new?template=bug_report.yml).
+
+        Before you continue:
+        * If you're using **Expo** and having problems updating it, [report it here](https://github.com/expo/expo/issues).
+        * If you're found a problem with our **documentation**, [report it here](https://github.com/facebook/react-native-website/issues/).
+        * If you're having an issue with **Metro** (the bundler), [report it here](https://github.com/facebook/metro/issues/).
+        * If you're using an external library, report the issue to the **library first**.
+        * Please [search for similar issues](https://github.com/facebook/react-native/issues) in our issue tracker.
+
+        Make sure that your issue:
+        * Have a **valid reproducer** with an [empty project from template](https://github.com/react-native-community/reproducer-react-native).
+        * Is upgrading to the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
+
+        Due to the extreme number of bugs we receive, we will be looking **ONLY** into issues with a reproducer, and on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native.
+  - type: input
+    id: old-version
+    attributes:
+      label: Old Version
+      description: The version of react-native that you're upgrading from.
+      placeholder: "0.73.0"
+    validations:
+      required: true
+  - type: input
+    id: new-version
+    attributes:
+      label: New Version
+      description: The version of react-native that you're upgrading to. Bear in mind that only issues that are upgrading to the [latest stable](https://github.com/facebook/react-native/releases/) will be looked into.
+      placeholder: "0.74.0"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The list of steps and commands to reproduce the issue.
+      placeholder: |
+        1. Install the application with `yarn android`
+        2. Click on the button on the Home
+        3. Notice the crash
+    validations:
+      required: true
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Affected Platforms
+      description: Please select which platform you're developing to, and which OS you're using for building.
+      multiple: true
+      options:
+        - Runtime - Android
+        - Runtime - iOS
+        - Runtime - Web
+        - Runtime - Desktop
+        - Build - MacOS
+        - Build - Windows
+        - Build - Linux
+        - Other (please specify)
+    validations:
+      required: true
+  - type: textarea
+    id: react-native-info
+    attributes:
+      label: Output of `npx react-native info`
+      description: Run `npx react-native info` in your terminal, copy and paste the results here.
+      placeholder: |
+        Paste the output of `npx react-native info` here. The output looks like:
+        ...
+        System:
+          OS: macOS 14.1.1
+          CPU: (10) arm64 Apple M1 Max
+          Memory: 417.81 MB / 64.00 GB
+          Shell:
+            version: "5.9"
+            path: /bin/zsh
+        Binaries:
+          Node: ...
+            version: 18.14.0
+        ...
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stacktrace or Logs
+      description: Please provide a stacktrace or a log of your crash or failure
+      render: text
+      placeholder: |
+        Paste your stacktraces and logs here. They might look like:
+
+        java.lang.UnsatisfiedLinkError: couldn't find DSO to load: libfabricjni.so caused by: com.facebook.react.fabric.StateWrapperImpl result: 0
+            at com.facebook.soloader.SoLoader.g(Unknown Source:341)
+            at com.facebook.soloader.SoLoader.t(Unknown Source:124)
+            at com.facebook.soloader.SoLoader.s(Unknown Source:2)
+            at com.facebook.soloader.SoLoader.q(Unknown Source:42)
+            at com.facebook.soloader.SoLoader.p(Unknown Source:1)
+            ...
+    validations:
+      required: true
+  - type: input
+    id: reproducer
+    attributes:
+      label: Reproducer
+      description: A link to a Expo Snack or a public repository that reproduces this bug, using [this template](https://github.com/react-native-community/reproducer-react-native). Reproducers are **mandatory**.
+      placeholder: "https://github.com/<myuser>/<myreproducer>"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Screenshots and Videos
+      description: |
+        Please provide screenshot or a video of your bug if relevant.
+        Issues with videos and screenshots are more likely to **get prioritized**.


### PR DESCRIPTION
 Pick Requests and Test Reports.,These will serve as issue templates for our GitHub Project based Release management. Once finalized, we will link to these from https://github.com/facebook/react-native/issues/new/choose

The Upgrade Regression form is a 1:1 copy of the form in the facebook/react-native repository, and seeks to replace that, directing the issues to this repository instead.

The Pick Request Form aims to replace the freeform comments requesting picks in eg https://github.com/reactwg/react-native-releases/discussions/104, so that we can make use of the Project Management flows to track the progress and outcome of these requests.

The Test Report Form aims to replace the test progress reporting in `#releases-crew` on Discord. This is currently a limited visibility destination, making test reports public and structure in issues may help triaging and root causing issues later on.

The issues generated via these forms will be ingested to the appropriate projects via Workflows. Those are to follow ASAP.
To protect this repository against spam issues in other catagories, the `config.yml` disallows freeform issue creation in this repo.