### PR TITLE
docs: fix formatting in fig caption to correctly render code

### DIFF
--- a/docs/guide-publish-monorepo.md
+++ b/docs/guide-publish-monorepo.md
@@ -27,7 +27,7 @@ Push the local commit to the remote release branch. This will trigger CI to publ
 
 <figure>
 <img alt="CircleCI publishing monorepo packages" src="../assets/find_and_publish_bumped_packages.png" width="400" />
-<figcaption>Pushing the `yarn bump-all-updated-packages` commit to CircleCI on the 0.73 branch will trigger the `find_and_publish_bumped_packages` job which handles the npm publish.</figcaption>
+<figcaption>Pushing the <code>yarn bump-all-updated-packages</code> commit to CircleCI on the 0.73 branch will trigger the <code>find_and_publish_bumped_packages</code> job which handles the npm publish.</figcaption>
 </figure>
 
 **Wait for this to complete, [see gotcha](./gotchas.md#circleci-only-runs-1-workflow-at-a-time).**
@@ -38,7 +38,7 @@ This means that if your `main` (on your release branch) and the minor column mat
 
 <figure>
 <img alt="yarn print-packages" src="../assets/yarn_print_packages.png" width="400" />
-<figcaption>Running `yarn print-packages` in your release branch.</figcaption>
+<figcaption>Running <code>yarn print-packages</code> in your release branch.</figcaption>
 </figure>
 
 ### Step 3. Repeat
@@ -72,7 +72,7 @@ This means that if your `main` (on your release branch) and the minor column mat
 
 <figure>
 <img alt="yarn print-packages" src="../assets/yarn_print_packages.png" width="400" />
-<figcaption>Running `yarn print-packages` in your release branch.</figcaption>
+<figcaption>Running <code>yarn print-packages</code> in your release branch.</figcaption>
 </figure>
 
 > [!Note]

--- a/docs/guide-release-process.md
+++ b/docs/guide-release-process.md
@@ -101,7 +101,7 @@ The script will then output a link to the CI workflow `package_release`
 
 <figure>
 <img src="../assets/package_release.png" width="400" />
-<figcaption>CircleCI workflow "package_release". This workflow will then trigger another workflow that actually publishes the release.</figcaption>
+<figcaption>CircleCI workflow <code>package_release</code>. This workflow will then trigger another workflow that actually publishes the release.</figcaption>
 </figure>
 
 Once `package_release` workflow is complete, it will trigger a workflow on the release branch to bump the version number (see "1" in figure), commit and tag the commit with the version. This new tag will then trigger a workflow to publish the release (see "2" in figure).
@@ -132,10 +132,10 @@ You should expect the `main` and `minor` column versions to match.
 
 <figure>
 <img alt="yarn print-packages" src="../assets/yarn_print_packages.png" width="400" />
-<figcaption>Running `yarn print-packages` in your release branch.</figcaption>
+<figcaption>Running <code>yarn print-packages</code> in your release branch.</figcaption>
 </figure>
 
-#### Sanity-check by `init`-ing a new template app
+#### Sanity-check by init-ing a new template app
 
 Sanity check by init-ing a new project and running for iOS/Android
 

--- a/docs/guide-release-testing.md
+++ b/docs/guide-release-testing.md
@@ -104,7 +104,7 @@ To ensure that we cover the most use cases, we need to ensure we test all these 
 
 - **Debugger launch flow**
   - Use Dev Menu > Open Debugger.
-  - **0.73 and later**: Use `npx react-native-start --experimental-debugger`. Should connect to Hermes debugger in experimental new debugger frontend.
+  - **0.73 and later**: Use `npx react-native start --experimental-debugger`. Should connect to Hermes debugger in experimental new debugger frontend.
   - **Pre-0.73**: Should connect to Hermes debugger in Flipper.
 - **Console tab**
   - **All versions**: Should display all logs.


### PR DESCRIPTION
### Details:

This fixes the formatting in `figcaption` where the code samples wrapped in backticks doesn't render properly in markdown file.