### PR TITLE
Do not `git commit -a` in guide-release-process-0.74.md

### DIFF
--- a/docs/guide-release-process-0.74.md
+++ b/docs/guide-release-process-0.74.md
@@ -215,8 +215,9 @@ git pull
 cd packages/rn-tester
 bundle exec pod update hermes-engine --no-repo-update
 
-# Should contain updated packages/rn-tester/Podfile.lock
-git commit -a -m "Update Podfile.lock" -m "Changelog: [Internal]"
+# Commit only changes to packages/rn-tester/Podfile.lock
+git add packages/rn-tester/Podfile.lock
+git commit -m "Update Podfile.lock" -m "Changelog: [Internal]"
 git push
 ```
 


### PR DESCRIPTION
We should not commit everything with `git commit -a` at this step of the release process, but just the `packages/rn-tester/Podfile.lock` file