### PR TITLE
Make the version input in the pick-request more explicit

### DIFF
--- a/.github/ISSUE_TEMPLATE/pick_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/pick_request_form.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Target Branch(es)
       description: Please input which Release Branch(es) need this pick, eg `0.74, 0.73`. See our [Releases Support Policy](https://github.com/reactwg/react-native-releases#releases-support-policy).
-      placeholder: "0.74"
+      placeholder: "0.XX"
     validations:
       required: true
   - type: input


### PR DESCRIPTION
This change make sure that it's obvious that the Target branch field needs to be populated by the person who is submitting the issue and that the placeholder is not a prepopulated input.