### PR TITLE
docs: Add step to ping team in release process documentation

### DIFF
--- a/docs/guide-release-process.md
+++ b/docs/guide-release-process.md
@@ -79,6 +79,7 @@ There may be exceptional cases where we can bypass 2 release tests or only do se
 [Publish monorepo packages](./guide-publish-monorepo.md).
 
 ### Step 7. Publish `react-native`
+Before running the command, make sure to ping the team in the `#release-crew` discord channel and get a thumbs up.
 ```bash
 # Run
 yarn trigger-react-native-release --to-version <YOUR_RELEASE_VERSION> --token <YOUR_CIRCLE_CI_TOKEN>

--- a/docs/guide-release-process.md
+++ b/docs/guide-release-process.md
@@ -80,6 +80,10 @@ There may be exceptional cases where we can bypass 2 release tests or only do se
 
 ### Step 7. Publish `react-native`
 Before running the command, make sure to ping the team in the `#release-crew` discord channel and get a thumbs up.
+
+Also, **do not release on Fridays**. 
+This is to ensure that any potential issues can be addressed promptly without impacting the weekend.
+
 ```bash
 # Run
 yarn trigger-react-native-release --to-version <YOUR_RELEASE_VERSION> --token <YOUR_CIRCLE_CI_TOKEN>


### PR DESCRIPTION
### Summary

This PR updates the release process documentation to include a step for team communication.

### Changes

- Added a step to ping the team in the `#release-crew` Discord channel and get a thumbs up before running the release command.
- Added a note to not release on a Friday.