### PR TITLE
Update guide for 0.74 to pass the token to the changelog generator

### DIFF
--- a/docs/guide-release-process-0.74.md
+++ b/docs/guide-release-process-0.74.md
@@ -150,7 +150,8 @@ npx @rnx-kit/rn-changelog-generator \
   --base v<LATEST_STABLE_OR_RC>\
   --compare v<YOUR_NEW_VERSION> \
   --repo . \
-  --changelog ./CHANGELOG.md
+  --changelog ./CHANGELOG.md \
+  --token <YOUR_GITHUB_TOKEN>
 ```
 
 You'll likely need to reformat the generated `CHANGELOG.md` changes and reorder the heading to keep the latest release ordering. Once done, create a PR with your changes against `main`.


### PR DESCRIPTION
Update the guide for 0.74 to pass the token to the changelog generator.