### PR TITLE
Publish the new pick requests acceptance criteria for 2025

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -50,43 +50,65 @@ Cherry-Pick requests should be submitted as a [cherry-pick issue](https://github
 
 Please note that each cherry-pick request will be assessed and approved individually. Cherry-Pick requests against unsupported versions will be rejected unless they involve security issues.
 
-## Release Issues and Pick Request Escalation
 
-The following is how we escalate release issues and pick requests.
+## Cherry-pick Requests
 
-- P0
-    - Immediate escalation to address and release patches for all affected versions in support window.
-- P1
-    - Regression should be triaged, addressed and shipped in a patch in a 2 week window for affected versions in support window. Priority will be given to latest stable version.
-- P2 / No Pick
-    - No prioritization will be given and no guarantee it will be picked. May still be shipped with with P0/P1 escalated patches upon discretion of release crew.
+A cherry-pick request is the request to include a fix in one of the **supported versions**.
 
-### Escalation Framework
+Cherry-Pick requests should be submitted as a [cherry-pick issue](https://github.com/reactwg/react-native-releases/issues/new/choose) in this repo. It will be triaged by the release crew.
 
-| Regression Area                                       | Default   | 0.76      | 0.75      | 0.74      | 0.73      |
-| ----------------------------------------------------- | -         | -         | -         | -         | -         |
-| Build regression for recommended workflows | P0 |
-| Publishing to App/Play Store | P0 |
-| Security risks (High vulnerability) | P0 |
-| Security risks (Low vulnerability) | P1 |
-| Developer Workflows (Fast Refresh, Dev Menu, see debugging flavors) | P0 |
-| Poor Developer Experience that does not break functionality | P1 |
-| Flipper Debugging (Hermes)                            | -         | No Pick   | No Pick   | P0        | P0        |
-| Flipper Debugging (JSC)                               | -         | No Pick   | No Pick   | P0        | P0        |
-| [Chrome Remote Debugging (JSC)](chrome-debugigng)     | -         | No Pick   | P1        | P0        | P0        |
-| [Chrome Remote Debugging (Hermes)](chrome-debugging)  | -         | P0        | P0        | P0        | P0        |
-| [Experimental Debugger](experimental-debugging)       | -         | P1        | No Pick   | n/a       | n/a       |
-| New regressions on documented Core APIs (components, APIs) | P0 |
-| Core APIs (components, APIs) with workarounds | P1 |
-| Regressions on non-recommended tooling, ex. pnpm, Swift | P1 |
-| P0 Regressions only affecting out-of-tree platforms (subject to release-crew) | P1 |
-| Non-critical improvements that have landed on `main` | P2 |
-| Performance improvement work | P2 |
+Please note that each cherry-pick request will be assessed and approved individually, following the criteria highlighted below.
 
-Affected platform will also be considered with the following priority:
-- Mobile (Android, iOS)
-- Desktop (macOS, Windows)
-- Web
-- TV
-- Skia
-- Other
+> [!IMPORTANT]  
+> The release crew evaluates each pick on a case-by-case basis (for example a fix may be included in one supported version but not another). The release crew have a lot of flexibility so long as they feel the change would significantly improve the quality or stability of a version of React Native.
+
+### Which pick requests we accept:
+
+1. ✅ Fixes for regressions to core APIs. Examples:
+    * A core component is behaving differently between version 0.X and 0.X-1
+    * The TurboModule.getEnforcing function is throwing an assertion error which is not expected.
+2. ✅ Fixes to bugs in the core React Native’s experience. Examples:
+    * Breakpoints in React Native DevTools not working correctly in the debugger
+    * Fast Refresh not working as expected
+    * Metro bundler not starting properly or ignoring the configuration file
+    * Buttons that are not clickable
+3. ✅ Fixes to APIs used by 3P libraries and Out-of-tree platforms. Examples:
+    * An API that is used by `react-native-macos` is not behaving as expected or regressing
+4. ✅ Bump of patch version of dependencies. Example:
+    * Bump Gradle from 8.11.0 to 8.11.1
+5. ✅ Fixes for Low/High Security Vulnerability. Example:
+    * Bump Gradle from 8.11.0 to 8.12.0 if there is a security vulnerability in 8.11 and there is no version 8.11.x which would contain the same fix.
+6. ✅ Fixes and reverts of accidental breaking changes. Example:
+    * Reverting or fix-forwarding a migration to Kotlin of a file (say `ReactRootView.java` ) if that is causing a breaking change for the whole React Native ecosystem.
+7. ✅ Performance improvements picks. Examples:
+    * Fixing unnecessary rendering on FlatList.
+8. ✅ Any pick if the release is still in RC0 (after RC1 the previous listed criteria applies)
+
+### Which pick requests we don’t accept
+
+9. ❌ Any pick that will introduce a breaking change after RC1. Example:
+    * A bugfix that contains a refactoring, resulting in changes to the public API of a class
+10. ❌ Any pick that introduces a new feature after RC1. Example:
+    * A commit that introduces a new API or a specific feature for a component.
+11. ❌ Bump of major/minor version of dependencies. Example:
+    * Bump Gradle from 8.11.0 to 8.12.0
+    * Bump Gradle from 8.11.0 to 9.0.0
+12. ❌ Bump of a dependency to a non stable/alpha/beta version. Example:
+    * Bump Gradle from 8.11.0 to 8.11.1-beta.1
+13. ❌ Any pick that introduces changes to the testing infrastructure of React Native after RC1. Examples:
+    * Changes to the GitHub Actions workflows to optimize it, even if they’re on main.
+    * Changes to the logic used to publish packages to NPM or Maven Central
+14. ❌ Pick composed by various commits that has several merge conflicts
+    * If your pick is too complicated to apply on the release branch, we’re going to reject it.
+15. ❌ Any other non-critical improvement that landed on main.
+    * In general those will ship in the following version unless they fit in one of the criteria above
+16. ❌ Any other pick which is considered “small enough” to make it into a release.
+    * If your pick is a one liner but is a ‘nice to have’, we won’t be picking it, as it has the risk of destabilizing the release and further delaying the release.
+
+### What makes for a good pick
+
+In order to increase the chance for your pick to be considered, please consider doing the following:
+
+* Have a pick that contains only one commit from `main`, or only one PR against the release branch.
+* Have a clear explanation of why your pick should be considered, ideally referencing one of the criteria above.
+* Target only one minor version of React Native (e.g. 0.76). If you want your pick to be applied to more versions, please open different picks.


### PR DESCRIPTION
Publishing the new Pick Request criteria for 2025. I'm planning on having a bot publishing them in every opened pick request for the sake of visibility.