### PR TITLE
Correctly reflect min XCode bump to 16.1 in 0.81

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -36,7 +36,7 @@ When a version is in the unsupported stage, no new released are to be expected. 
 
 | Version               | Android SDK minimum   | JDK version           | Xcode Version min.    | Cocoapods             | Node min.             |
 | --------------------- | --------------------- | --------------------- | --------------------- | --------------------- | --------------------- |
-| 0.81                  | Android 7.0           | JDK 17                | 15.1                  | 1.13.x/1.14.x/1.15.2  | 22.14.0               |
+| 0.81                  | Android 7.0           | JDK 17                | 16.1                  | 1.13.x/1.14.x/1.15.2  | 22.14.0               |
 | 0.80                  | Android 7.0           | JDK 17                | 15.1                  | 1.13.x/1.14.x/1.15.2  | 18                    |
 | 0.79                  | Android 7.0           | JDK 17                | 15.1                  | 1.13.x/1.14.x/1.15.2  | 18                    |
 | 0.78                  | Android 7.0           | JDK 17                | 15.1                  | 1.13.x/1.14.x/1.15.2  | 18                    |


### PR DESCRIPTION
See:
- https://github.com/facebook/react-native/pull/51762

This is going to be shipped in 0.81