### PR TITLE
docs: make rn-release-automator CLI the default release path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Please refer to the official [Support Policy](https://github.com/reactwg/react-n
 
 ## Running a React Native Release
 
+> [!TIP]
+> The recommended way to run a release is the **[`rn-release-automator` CLI](./docs/guide-release-cli.md)**. It walks you through every phase with interactive prompts and pre-flight checks:
+>
+> ```sh
+> npx rn-release-automator@latest
+> ```
+>
+> Every guide below leads with the relevant CLI command and keeps the manual steps in collapsible sections. Always run mutating commands with `--dry-run` first — see the [Release CLI guide](./docs/guide-release-cli.md) to get started.
+
 React Native releases are run by a group of volunteers called the **Release Crew**.
 In those docs you can find clarification about the roles of the various members of the Release Crew:
 
@@ -24,6 +33,7 @@ In those docs you can find clarification about the roles of the various members 
 
 In those docs instead you can find step-by-step guides on how to run a React Native release
 
+- [Guide: Release CLI (`rn-release-automator`)](./docs/guide-release-cli.md) — **start here**
 - [Guide: Running a Release](./docs/guide-release-process.md)
 - [Guide: Release Candidates](./docs/guide-release-candidate.md)
   - [How to setup a new release project](./docs/guide-release-project-setup.md)

--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -3,6 +3,9 @@
 > [!Important]
 > Only Meta release crew should publish Hermes releases. If you are a community releaser that is picking a Hermes pick request, ping a Meta release crew member to publish the Hermes release.
 
+> [!NOTE]
+> Publishing the Hermes tags is a **manual, Meta-only** flow — follow the steps below. The [`rn-release-automator` CLI](./guide-release-cli.md) does not publish Hermes itself, but its `cut-branch` command **guides you through the React-Native-side steps**: it opens this guide at the right moment, then prompts for the new Hermes tag(s) and runs the `bump-hermes-version.js` script + commit + push for you ([Step 4](#step-4-bump-the-hermes-version-on-the-react-native-release-branch)). `prepare-release` also flags any Hermes-related pick requests as 🔴 so they aren't picked automatically.
+
 Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebook/hermes). You can give yourself permission via the Meta Internal OSS dashboard.
 
 See the guide you need, based on the React native release you are running:

--- a/docs/guide-release-candidate.md
+++ b/docs/guide-release-candidate.md
@@ -18,6 +18,21 @@ The general stages for handling a release candidate:
 
 ## Cut a Release Candidate
 
+> [!TIP]
+> The whole branch cut is automated by `cut-branch`. Its interactive workflow: verifies your repo state, checks CI on `main`, prompts you to update the external dependencies table, creates the `X.Y-stable` branch (and the matching branch in `react-native-community/template`), notifies the #cli Discord channel, triggers a nightly, walks you through the [Hermes release](./guide-hermes-release.md) and version bump, and prints the follow-ups.
+>
+> **Preview with `--dry-run` first**, then run it for real:
+>
+> ```sh
+> npx rn-release-automator@latest cut-branch --series 0.85 --dry-run
+> npx rn-release-automator@latest cut-branch --series 0.85
+> ```
+>
+> When it finishes, continue with [`create-github-project`](./guide-release-project-setup.md) and [`prepare-release`](./guide-release-process.md#step-2-action-cherry-picks-and-pull-requests). The manual equivalents of each phase are below and in the linked general release process.
+
+<details>
+  <summary><b>Manual steps</b> — cut the branch by hand (steps 0–3)</summary>
+
 ### 0. Update External Dependencies
 
 Add a new column for this release candidate in the [External Dependencies Supported table](./support.md#external-dependencies-supported). Follow up internally if unsure.
@@ -70,6 +85,8 @@ To trigger a nightly:
 
 <img src="../assets/trigger-nightly.png" width="600" />
 
+</details>
+
 At this point, you'll follow the general release process as per the following links:
 
 ### [3. Push branch & Wait for Github Actions artifacts to build](./guide-release-process.md#step-3-wait-for-github-actions-artifacts-to-build)
@@ -115,6 +132,14 @@ You can follow the general release process for patches. The only thing to note i
 
 ex. 0.78.0-rc.1 -> 0.78.0-rc.2
 
+With the CLI, `prepare-release` detects the current RC and offers the next one automatically:
+
+```sh
+npx rn-release-automator@latest prepare-release --series 0.85   # choose "Next RC"
+npx rn-release-automator@latest publish --version 0.85.0-rc.2 --dry-run
+npx rn-release-automator@latest publish --version 0.85.0-rc.2
+```
+
 [See guide to release process](./guide-release-process.md)
 
 ## Promote release candidate to stable
@@ -123,7 +148,28 @@ Promoting a release candidate to stable is similar to releasing a patch. The dif
 
 As well, there is follow-up in terms of writing a blog post and communicating to the ecosystem about this release.
 
+> [!TIP]
+> With the CLI, promote and then run the post-promotion follow-ups:
+>
+> ```sh
+> # 1. Release the stable version (choose "Promote to stable" when prompted)
+> npx rn-release-automator@latest prepare-release --series 0.85
+> npx rn-release-automator@latest publish --version 0.85.0 --dry-run
+> npx rn-release-automator@latest publish --version 0.85.0
+> npx rn-release-automator@latest verify-release --series 0.85
+>
+> # 2–4. Support policy table, blog post, and website version cut
+> npx rn-release-automator@latest post-promotion --series 0.85
+> ```
+
 ### 1. Release a stable version following [release process](./guide-release-process.md)
+
+In the CLI, run `prepare-release --series 0.85` and choose **Promote to stable**, then `publish --version 0.85.0` (with `--dry-run` first) and `verify-release --series 0.85`.
+
+Steps 2–4 below (support policy table, blog post, website version cut) are all driven by `post-promotion --series 0.85`. It generates the updated support-policy table for you and can open the file in the GitHub editor or copy the table to your clipboard, then opens the website PRs page and version-cutting instructions.
+
+<details>
+  <summary><b>Manual steps</b> — post-promotion follow-ups by hand (steps 2–4)</summary>
 
 ### 2. Update the React Native support policy
 
@@ -157,3 +203,5 @@ Example:
 - Head to [react-native-website](https://github.com/facebook/react-native-website)
 - Make sure all relevant PRs for release candidate are merged
 - Cut a new version of the website, [instructions](https://github.com/facebook/react-native-website#cutting-a-new-version)
+
+</details>

--- a/docs/guide-release-cli.md
+++ b/docs/guide-release-cli.md
@@ -1,0 +1,128 @@
+# Release CLI (`rn-release-automator`)
+
+> [!TIP]
+> `rn-release-automator` is the **recommended** way to run a React Native release. It walks you through every phase of a release with interactive prompts, pre-flight checks, and GitHub API integrations — so you don't have to remember each manual step.
+>
+> Every guide in this repo now leads with the relevant CLI command and keeps the manual steps available in collapsible **Manual steps** sections for reference or fallback.
+
+## Quick start
+
+Run the interactive menu — no install required:
+
+```sh
+npx rn-release-automator@latest
+```
+
+Pick what you want to do from the menu, or invoke a command directly:
+
+```sh
+npx rn-release-automator@latest status
+npx rn-release-automator@latest prepare-release --series 0.85
+npx rn-release-automator@latest publish --version 0.85.0-rc.1
+```
+
+Use `--help` on the CLI or any command to see the available flags:
+
+```sh
+npx rn-release-automator@latest --help
+npx rn-release-automator@latest cut-branch --help
+```
+
+## Always dry-run first
+
+> [!CAUTION]
+> Before any command that **creates branches, comments on issues, triggers workflows, or otherwise mutates remote state**, run it once with `--dry-run`.
+>
+> Dry-run skips all mutations but still runs the read-only checks (CI status, npm queries, pick analysis, branch checks), so you can preview exactly what the command *would* do. Every interactive prompt shows a red `DRY RUN` badge while it's active.
+
+```sh
+# Preview, then run for real
+npx rn-release-automator@latest cut-branch --series 0.85 --dry-run
+npx rn-release-automator@latest cut-branch --series 0.85
+```
+
+The commands that mutate remote state — and therefore should always be dry-run first — are:
+
+- `cut-branch` — creates the stable branch, template branch, and commits/pushes the Hermes bump
+- `create-github-project` — clones a GitHub Project and deletes copied items
+- `prepare-release` — comments `@react-native-bot merge …` and can close pick requests
+- `publish` — triggers the `create-release.yml` workflow
+
+`--dry-run` can also be passed globally, before the command, and it applies to the whole run:
+
+```sh
+npx rn-release-automator@latest --dry-run
+```
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **[GitHub CLI](https://cli.github.com/) (`gh`)** authenticated — `gh auth login`
+- **Git** with push access to `facebook/react-native`
+- For GitHub Projects (`create-github-project`, `verify-release`): `gh auth refresh -s read:project,project`
+
+The CLI auto-discovers your GitHub token from the `GITHUB_TOKEN` environment variable, falling back to `gh auth token`. Run `init` to verify everything is set up:
+
+```sh
+npx rn-release-automator@latest init
+```
+
+`init` checks your tools, tokens, and access to the four repositories the CLI touches, and tells you whether your GitHub user is on the [`@react-native-bot` allow-list](https://github.com/reactwg/react-native-releases/blob/main/.github/workflows/react-native-bot-merger.yml) (needed to use bot merges during `prepare-release`).
+
+## Command reference
+
+Commands are either **series-scoped** (`--series 0.85`) or **version-specific** (`--version 0.85.0-rc.1`).
+
+| Command | Input | What it does | Guide |
+|---------|-------|--------------|-------|
+| `init` | — | Validate environment — tools, tokens, repo access, bot merger list | [Onboarding](./roles-and-responsibilities.md#onboarding-to-release-crew) |
+| `status` | `--series` or none | Overview of all release series, or details for one | — |
+| `cut-branch` | `--series` | RC0 branch cut — CI check, create stable & template branches, notify #cli, trigger nightly, Hermes bump | [Release Candidate](./guide-release-candidate.md#cut-a-release-candidate) |
+| `create-github-project` | `--series` | Clone and configure a GitHub Project for the release | [Project Setup](./guide-release-project-setup.md) |
+| `prepare-release` | `--series` | Analyze pick requests, determine the next version (RC / stable / patch), process picks via bot | [Release Process](./guide-release-process.md#step-2-action-cherry-picks-and-pull-requests) |
+| `publish` | `--version` | Pre-flight checks, trigger `create-release.yml`, monitor | [Release Process](./guide-release-process.md#step-5-create-release) |
+| `test-release` | `--version` | Verify repo/branch, clean env, download prebuilds, print the test matrix | [Release Testing](./guide-release-testing.md) |
+| `verify-release` | `--series` | 8-step post-release verification (npm, template, upgrade helper, Maven, changelog, GitHub release, communicate, project) | [Release Process](./guide-release-process.md#step-6-verify-release) |
+| `post-promotion` | `--series` | Update support policy table, ship blog post, cut a new website version | [Promote to stable](./guide-release-candidate.md#promote-release-candidate-to-stable) |
+| `communicate` | `--version` | Generate announcement templates (status tracker, Discord, GitHub release body) | [Release Process](./guide-release-process.md#step-9-communicate-release) |
+
+## Typical workflow
+
+A full release-candidate cycle, in order:
+
+```sh
+# 1. Verify your environment
+npx rn-release-automator@latest init
+
+# 2. Cut the stable branch (RC0 only) — dry-run first!
+npx rn-release-automator@latest cut-branch --series 0.85 --dry-run
+npx rn-release-automator@latest cut-branch --series 0.85
+
+# 3. Set up the tracking project (new minor only) — dry-run first!
+npx rn-release-automator@latest create-github-project --series 0.85 --dry-run
+npx rn-release-automator@latest create-github-project --series 0.85
+
+# 4. Cherry-pick fixes and choose the next version — dry-run first!
+npx rn-release-automator@latest prepare-release --series 0.85 --dry-run
+npx rn-release-automator@latest prepare-release --series 0.85
+
+# 5. Trigger the release — dry-run first!
+npx rn-release-automator@latest publish --version 0.85.0-rc.0 --dry-run
+npx rn-release-automator@latest publish --version 0.85.0-rc.0
+
+# 6. Test the release (RC0, RC1, RC4, stable)
+npx rn-release-automator@latest test-release --version 0.85.0-rc.0
+
+# 7. Verify the published release
+npx rn-release-automator@latest verify-release --series 0.85
+
+# 8. Announce it
+npx rn-release-automator@latest communicate --version 0.85.0-rc.0
+```
+
+For a **patch release** on an existing stable series, skip steps 2–3 and start at `prepare-release` (it will offer the next patch version automatically).
+
+For **promoting an RC to stable**, run `prepare-release` and choose *Promote to stable*, then `publish`, `verify-release`, and finally `post-promotion`.
+
+> [!NOTE]
+> The CLI covers the React-Native-side of the [Hermes release](./guide-hermes-release.md) (it prompts you through the version bump during `cut-branch`), but **publishing the Hermes tags themselves is still a manual, Meta-only step**. Follow the Hermes guide when prompted.

--- a/docs/guide-release-process.md
+++ b/docs/guide-release-process.md
@@ -8,9 +8,24 @@
 >
 > Follow the dedicated release candidate [guide](./guide-release-candidate.md) for more detail.
 
+> [!TIP]
+> The steps below are automated by the **[`rn-release-automator` CLI](./guide-release-cli.md)** — the recommended way to run a release. Each step leads with the CLI command and keeps the manual instructions in a collapsible **Manual steps** section. For a patch or incremental RC, the two commands you'll use most are:
+>
+> ```sh
+> npx rn-release-automator@latest prepare-release --series 0.85   # cherry-picks + choose next version
+> npx rn-release-automator@latest publish --version 0.85.0-rc.1   # trigger the release
+> ```
+>
+> Always preview mutating commands with `--dry-run` first. See the [Release CLI guide](./guide-release-cli.md) for setup and the full command reference.
+
 ## Release steps
 
-These steps apply when making a patch release or an incremental release candidate.  Typically we like to keep the *#release-crew* Discord channel up to date with progress.  You're free to do this however you'd like.  One method is it keep a progress message up-to-date (⌛ started, ✅ complete, 🚨 problem).  Here is the template used for 0.78.0-rc.0:
+These steps apply when making a patch release or an incremental release candidate.  Typically we like to keep the *#release-crew* Discord channel up to date with progress.  You're free to do this however you'd like.  One method is it keep a progress message up-to-date (⌛ started, ✅ complete, 🚨 problem).
+
+> [!TIP]
+> The CLI generates this progress template for you — run `npx rn-release-automator@latest communicate --version <version>` (or pick **Communicate** from the menu) and copy the **Release Status Message**.
+
+Here is the template used for 0.78.0-rc.0:
 
 ```md
 # 0.78.0-rc.0
@@ -33,6 +48,13 @@ These steps apply when making a patch release or an incremental release candidat
 
 ### Step 1: Check out release branch locally
 
+> [!TIP]
+> Get an overview of the series (branch, CI, npm, pending picks) first with:
+> ```sh
+> npx rn-release-automator@latest status --series 0.85
+> ```
+> Checking out the branch is a local git operation, so do it yourself as below. `prepare-release` (Step 2) will verify the branch exists before doing anything.
+
 From your local `facebook/react-native` clone, check out the relevant [release branch](./glossary.md#release-branch). Make sure your system is set up with the right [tooling dependencies](./support.md#external-dependencies-supported) for the release. e.g. you may need to switch Node versions.
 
 ```sh
@@ -52,6 +74,25 @@ New changes targeting a given release need to be replicated from `main` onto the
 
 ![CleanShot 2024-12-09 at 11 08 50@2x](https://github.com/user-attachments/assets/5fe54818-230d-4ab6-b6fd-0a576a32008f)
 
+Once the project is up to date, let the CLI analyze the pending pick requests and process them for you. **Preview first with `--dry-run`**, then run it for real:
+
+```sh
+npx rn-release-automator@latest prepare-release --series 0.85 --dry-run
+npx rn-release-automator@latest prepare-release --series 0.85
+```
+
+`prepare-release` will:
+
+- Fetch the latest published version in the series and let you pick the **next version** (next RC, promote to stable, or next patch).
+- Check CI status and list any **unpublished commits** already on the branch.
+- Classify each open [pick request](https://github.com/reactwg/react-native-releases/issues) — e.g. 🟢 *can be bot-merged*, 🟡 *not on main yet*, 🔵 *PR targets the branch*, 🔴 *Hermes / multi-target / complex* — and, for bot-mergeable picks, comment `@react-native-bot merge <sha> <branch>` for you (skipped in dry-run). It can also close pick requests whose PR is already merged.
+
+> [!Warning]
+> For any pick requests or merge requests for Hermes, notify a Meta Release Crew member. They'll need to publish and pick the [Hermes release](./guide-hermes-release.md) into the release branch. Do not proceed past step 3 until the the branch has been updated with the Hermes release. The CLI flags Hermes-related picks as 🔴 and leaves them for manual handling.
+
+<details>
+  <summary><b>Manual steps</b> — cherry-pick without the CLI</summary>
+
 Once the project is up to date, you can pick these locally:
 
 ```bash
@@ -68,8 +109,7 @@ git cherry-pick <commit-on-main>
 Alternatively, you can also pick via **react-native-bot** by leaving a comment: 
 `@react-native-bot merge <commit_id> 0.xx-stable`
 
-> [!Warning]
-> For any pick requests or merge requests for Hermes, notify a Meta Release Crew member. They'll need to publish and pick the [Hermes release](./guide-hermes-release.md) into the release branch. Do not proceed past step 3 until the the branch has been updated with the Hermes release.
+</details>
 
 ### Step 3: Wait for Github Actions artifacts to build
 
@@ -80,6 +120,9 @@ git push
 ```
 
 This will kick off a Github Action workflow called [Test All](https://github.com/facebook/react-native/actions/workflows/test-all.yml) that will build relevant artifacts (Hermes prebuilts, `RNTester.apk`) that will expedite local testing.
+
+> [!TIP]
+> You don't have to watch the Actions tab manually — `prepare-release`, `publish`, and `test-release` all check CI status on the branch before continuing, and `status --series 0.85` shows the latest workflow runs at any time.
 
 [Navigate to Github Actions](https://github.com/facebook/react-native/actions/workflows/test-all.yml) and wait for the `build_npm_package` job to complete successfully (~30min into the `test-all` workflow). If the job fails, try and fix the issue so that the artifacts build.
 
@@ -95,7 +138,13 @@ This will kick off a Github Action workflow called [Test All](https://github.com
 
 ### Step 4: Test the release
 
-Follow the [Release Testing guide](./guide-release-testing.md). 
+Kick off local testing with the CLI, which verifies your repo/branch and CI, cleans the environment, wires up prebuild downloads, and prints the test matrix:
+
+```sh
+npx rn-release-automator@latest test-release --version 0.85.0-rc.0
+```
+
+Then follow the [Release Testing guide](./guide-release-testing.md) for what and how to test.
 
 * We should have **1x Release Crew** member testing the release:
   * **Only** the following releases should be manually tested.
@@ -106,7 +155,21 @@ Follow the [Release Testing guide](./guide-release-testing.md).
 * You should ensure that the **E2E jobs** on the release branch are green.
 
 ### Step 5. Create release
-Starting from React Native 0.75, a new release is created using a Github Action workflow called [Create Release](https://github.com/facebook/react-native/actions/workflows/create-release.yml).
+
+Starting from React Native 0.75, a new release is created using a Github Action workflow called [Create Release](https://github.com/facebook/react-native/actions/workflows/create-release.yml). The CLI runs its pre-flight checks (CI green? pending picks? already published on npm?), triggers that workflow, and monitors it to completion.
+
+> [!CAUTION]
+> This publishes a release. **Always preview with `--dry-run` first** — it runs every read-only check and shows exactly what would be triggered, without triggering anything.
+
+```sh
+npx rn-release-automator@latest publish --version 0.85.0-rc.0 --dry-run
+npx rn-release-automator@latest publish --version 0.85.0-rc.0
+```
+
+The CLI picks the stable branch from the version, sets the `latest` flag automatically for stable (non-RC) releases, and keeps the workflow's dry-run input `false` for a real run. It then triggers the **Create Release** workflow ([create-release.yml](https://github.com/facebook/react-native/blob/main/.github/workflows/create-release.yml)), which syncs package versions ([publish-bumped-packages.yml](https://github.com/facebook/react-native/blob/main/.github/workflows/publish-bumped-packages.yml)), commits and publishes a tag. The new tag then launches the **Publish Release** workflow ([publish-release.yml](https://github.com/facebook/react-native/blob/main/.github/workflows/publish-release.yml#L2-L6)) which builds and publishes the `react-native` npm package artifact.
+
+<details>
+  <summary><b>Manual steps</b> — trigger the workflow from the GitHub UI</summary>
 
 <img src="../assets/create_release.png" width="600" />
 
@@ -124,9 +187,22 @@ The new tag will then launch a **Publish Release** workflow ([publish-release.ym
 
 <img src="../assets/release_process_jobs_gha.png" width="600" />
 
+</details>
+
 ### Step 6: Verify Release
 
-Once all workflows above are complete, verify the following:
+Once all workflows above are complete, run the interactive verification checklist. It finds the latest published version in the series and walks you through **8 post-release checks** — this single command covers Steps 6 through 9 and Step 11 below (npm, template, upgrade helper, Maven, changelog PR, GitHub release, communicate, and GitHub project):
+
+```sh
+npx rn-release-automator@latest verify-release --series 0.85
+```
+
+For each check the CLI offers to run it for you (e.g. `npm view`, `npx …init`, a Maven `curl`), open the relevant page in your browser, or skip.
+
+<details>
+  <summary><b>Manual steps</b> — verify each item by hand</summary>
+
+Verify the following:
 
 #### Verify npm publishes
 
@@ -227,7 +303,12 @@ curl -I https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts
 curl -I https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-core-dSYM-release.tar.gz
 ```
 
+</details>
+
 ### Step 7: Update CHANGELOG.md
+
+> [!TIP]
+> `verify-release` (Step 6) includes a step that opens the pending changelog PR for you to review and merge. This step describes what to do with it.
 
 Now we need to update the [`CHANGELOG.md`](https://github.com/facebook/react-native/blob/main/CHANGELOG.md) file at the `react-native` repo root.
 
@@ -267,6 +348,9 @@ npx @rnx-kit/rn-changelog-generator \
 </details>
 
 ### Step 8: Create the GitHub Release
+
+> [!TIP]
+> `verify-release` (Step 6) opens the draft GitHub release for this tag and reminds you whether to mark it as *Latest* (stable) or *Pre-release* (RC). Use `communicate --version <version>` to generate a release body template.
 
 > [!Note]
 > For large releases with many changelog changes such as RC0 (e.g. `0.81.0-rc.0`) or Major release (e.g. `0.81.0`) the link to CHANGELOG.md at the bottom of the Github release is enough.
@@ -331,9 +415,20 @@ EOF
 
 ### Step 9: Communicate Release
 
-Create and send a message with the template below in the Core Contributors Discord `#release-coordination` channel.
+Generate the announcement templates with the CLI:
 
-Get a Meta engineer to send that same message in the `React Native Releases` Workplace group.
+```sh
+npx rn-release-automator@latest communicate --version 0.81.0-rc.0
+```
+
+This prints ready-to-copy templates: the release **status** tracker, the **Discord** announcement (long and short forms), and the **GitHub release** body. Pass `--format discord-short` (or `discord`, `github`, `status`, `all`) to print just one.
+
+Send the short announcement in the Core Contributors Discord `#release-coordination` channel, and get a Meta engineer to send the same message in the `React Native Releases` Workplace group.
+
+<details>
+  <summary><b>Manual steps</b> — announcement template</summary>
+
+Create and send a message with the template below:
 
 ```
 📢 **0.81.0-rc.0 is out!**
@@ -341,6 +436,8 @@ Get a Meta engineer to send that same message in the `React Native Releases` Wor
 📦 Release tag: https://github.com/facebook/react-native/releases/tag/v0.81.0-rc.0
 📝 Changelog PR: https://github.com/facebook/react-native/pull/52517
 ```
+
+</details>
 
 ### Step 10: Ensure Podfile.lock is updated
 
@@ -378,5 +475,8 @@ git push
 
 
 ### Step 11: Update GitHub Project
+
+> [!TIP]
+> `verify-release` (Step 6) finishes by opening this project for you (it tries to auto-detect the project for the series).
 
 Make sure you've updated the status of completed and ongoing tasks in the relevant [GitHub project](https://github.com/reactwg/react-native-releases/projects?query=is%3Aopen). Unresolved items can be assigned to the following release.

--- a/docs/guide-release-project-setup.md
+++ b/docs/guide-release-project-setup.md
@@ -7,6 +7,21 @@ For every MINOR release, we create a Github Project to manage pick requests.  Yo
 - enable the `auto-add to project` workflow to make sure picks are visible to the correct project version
 - make the project publicly visible
 
+> [!TIP]
+> This is automated by `create-github-project`. It clones an existing project, renames it (`React Native 0.<minor>`), sets the description from the release schedule, makes it public, clears the copied items, and opens the pages where the remaining manual bits (crew access, status, auto-add workflow) are configured.
+>
+> **Preview with `--dry-run` first**, then run it for real:
+>
+> ```sh
+> npx rn-release-automator@latest create-github-project --series 0.85 --dry-run
+> npx rn-release-automator@latest create-github-project --series 0.85
+> ```
+>
+> GitHub Projects need the `project` scope — the CLI offers to run `gh auth refresh -s read:project,project` if it's missing.
+
+<details>
+  <summary><b>Manual steps</b> — set up the project from the GitHub UI</summary>
+
 Navigate to the **reactwg** projects page: https://github.com/orgs/reactwg/projects
 
 ## Copy the current release
@@ -34,3 +49,5 @@ https://github.com/user-attachments/assets/6adca6be-0abc-407d-9efc-26da693c5b3b
 
 ## Set project visibility to **public**
 https://github.com/user-attachments/assets/ad6720e3-24d0-436f-9f53-0a1a7863d61b
+
+</details>

--- a/docs/guide-release-testing.md
+++ b/docs/guide-release-testing.md
@@ -6,6 +6,18 @@
 > [!Caution]
 > Currently, this flow can only be done on macOS machines.
 
+> [!TIP]
+> The CLI drives the setup for you: it verifies you're on the right repo/branch, checks CI so prebuilds are available, offers to clean the environment, wires up your GitHub token for prebuild downloads, offers to open a new test report, and prints the four test-matrix commands to run.
+>
+> ```sh
+> npx rn-release-automator@latest test-release --version 0.85.0-rc.0
+> ```
+>
+> It only requires manual testing for RC0, RC1, RC4, and stable (and will tell you when testing is optional). Use the sections below (**What to test?** / **How to test?**) for what to exercise. The manual setup steps are collapsed just below.
+
+<details>
+  <summary><b>Manual steps</b> — set up and run the test matrix by hand</summary>
+
 ## Setup
 
 ### Check out + update target release branch
@@ -141,6 +153,8 @@ yarn test-release-local-clean && yarn
 yarn test-release-local -t "RNTestProject" -p "Android" -c $GITHUB_TOKEN
 # 6. Verify tests "what to test"
 ```
+
+</details>
 
 ## What to test?
 


### PR DESCRIPTION
Lead each release guide with the relevant CLI command and move the existing manual instructions into collapsible `<details>` sections. Recommend --dry-run before any command that mutates remote state (cut-branch, create-github-project, prepare-release, publish).

- Add docs/guide-release-cli.md: setup, dry-run guidance, command reference, and typical workflows
- README: point to the CLI as the recommended path
- guide-release-process / -candidate / -project-setup / -testing: lead with CLI, keep manual steps in `<details>`
- guide-hermes-release: note cut-branch drives the RN-side Hermes bump