### PR TITLE
Revise Hermes release guide for React Native updates

### DIFF
--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -9,10 +9,92 @@
 Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebook/hermes). You can give yourself permission via the Meta Internal OSS dashboard.
 
 See the guide you need, based on the React native release you are running:
-- [React Native >= 0.83](#for-react-native--083)
+- [React Native >= 0.87](#for-react-native--087)
+- [React Native 0.83 <= X < 0.87](#for-react-native--083-X-087)
 - [React Native < 0.82](#for-react-native--082)
 
-## For React Native >= 0.83
+## For React Native >= 0.87
+
+Starting from React Native 0.83, we need to have one tag for HermesV1.
+
+We decoupled the build of Hermes from the React Native repository and we can now consume Hermes binaries that are produced in the Hermes repository
+
+### Step 1: Cherry-pick
+
+> [!Important]
+> If you cutting a release candidate, skip this step
+
+1. Checkout the `250829098.0.0-stable` branch.
+2. Pick the relevant commits onto that branch. The pick requests should be from `static_h` and no other branch on Hermes.
+3. Push the picks to the remote branch.
+
+### Step 2: Build Hermes and Publish Tag
+
+Navigate to the [RN Build Hermes](https://github.com/facebook/hermes/actions/workflows/rn-build-hermes.yml) and run the workflow once.
+This workflow:
+- builds the Hermes artifacts;
+- publishes them on maven;
+- publishes the hermes-compiler to NPM;
+- publish the tag on GitHub
+
+The tag will be created as last step, and we need to wait for the whole process to end before React Native can start the Release.
+
+> [!Important]
+> If you are releasing a patch for Hermes V1 for the latest version of React Native, you also have to bump the patch number [`hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/250829098.0.0-stable/npm/hermes-compiler/package.json#L3) file from the `250829098.0.0-stable`
+
+1. Set the branch to the Hermes V1 release branch: `250829098.0.0-stable`
+2. Set the release type as `Release`
+
+### Step 4: Bump the Hermes version on the React Native release branch
+
+Using the newly generated Hermes tag run the following script on the React Native release branch:
+
+```bash
+# Replace <the_hermes_tag> with the tag that will look like 'hermes-2022-07-20-RNv0.70.0-bc97c5399e0789c0a323f8e1431986e207a9e8ba'
+./packages/react-native/scripts/hermes/bump-hermes-version.js -s <the_hermes_v1_tag>
+```
+
+An example of the invocation is:
+```
+./packages/react-native/scripts/hermes/bump-hermes-version.js -s hermes-v250829098.0.2
+```
+
+> [!Note]
+> The script also support the `-v` parameter to specify the Hermes V1 version.
+> When not passed, the script will check the latest version of hermes published on NPM and will prompt for confirmation.
+
+Add and commit the extra files that got created at:
+- packages/react-native/sdks/.hermesV1version
+and updated at:
+- packages/react-native/sdks/hermes-engine/version.properties
+- packages/react-native/package.json
+
+Now you can continue with the rest of your React Native release.
+
+```
+git add packages/react-native/sdks/.hermesvesion packages/react-native/sdks/.hermesv1vesion packages/react-native/sdks/hermes-engine/version.properties
+git commit -m "Bump hermes version"
+```
+
+### Step 5: Bump version on `main` and Hermes v1 release branch
+
+The `250829098.0.0-stable` should always track the next version that we are going to release.
+
+After the build started and the tag is generated, bump the hermes-compiler versions on those branches:
+
+From the `250829098.0.0-stable` branch
+1. Open the [`npm/hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/ddd708a85b164d1841c024973d0f6d3fad60a4c2/npm/hermes-compiler/package.json) file
+2. Bump the **patch** number by 1
+3. Commit and push.
+
+### Step 6: [Only for Branch Cut] Bump hermes versions on React Native `main` branch
+1. Go to the react-native repository
+2. Update the [`packages/react-native/sdks/hermes-engine/versions.properties` file]([url](https://github.com/facebook/react-native/blob/main/packages/react-native/sdks/hermes-engine/version.properties)) by bumping the `HERMES_V1_VERSION_NAME`
+This is an [example PR](https://github.com/facebook/react-native/pull/55042).
+
+---
+
+## For React Native 0.83 <= X < 0.87
 
 Starting from React Native 0.83, we need to have two tags for Hermes:
 - A tag for the (legacy) Hermes

--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -10,7 +10,7 @@ Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebo
 
 See the guide you need, based on the React native release you are running:
 - [React Native >= 0.87](#for-react-native--087)
-- [React Native 0.83 <= X < 0.87](#for-react-native--083-X-087)
+- [React Native 0.83 <= X < 0.87](#for-react-native-083--x--087)
 - [React Native < 0.82](#for-react-native--082)
 
 ## For React Native >= 0.87

--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -11,7 +11,6 @@ Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebo
 See the guide you need, based on the React native release you are running:
 - [React Native >= 0.87](#for-react-native--087)
 - [React Native 0.83 <= X < 0.87](#for-react-native-083--x--087)
-- [React Native < 0.82](#for-react-native--082)
 
 ## For React Native >= 0.87
 
@@ -220,51 +219,3 @@ From the `250829098.0.0-stable` branch
 1. Go to the react-native repository
 2. Update the [`packages/react-native/sdks/hermes-engine/versions.properties` file]([url](https://github.com/facebook/react-native/blob/main/packages/react-native/sdks/hermes-engine/version.properties)) by bumping the `HERMES_V1_VERSION_NAME`
 This is an [example PR](https://github.com/facebook/react-native/pull/55042).
-
----
-
-## For React Native < 0.82
-
-### Step 1: Check-out the Hermes release branch
-
-Check out the Hermes release branch for your minor. It should be of the form `rn/<major>.<minor>-stable`.
-
-> [!Tip]
-> If one doesn't exist and you are not releasing a release candidate, use the [latest tag](https://github.com/facebook/hermes/tags) for your minor. Check out that tag, and create the branch of the form `rn/<major>.<minor>-stable`. We should be creating these during release candidate cuts.
-
-### Step 2: Cherry-pick
-
-> [!Important]
-> If you cutting a release candidate, skip this step
-
-Pick the relevant commits onto that branch. The pick requests should be from `main` and no other branch on Hermes.
-
-Push the picks to the remote branch.
-
-### Step 3: Publish Tag
-
-Head to the [Publish Tag workflow](https://github.com/facebook/hermes/actions/workflows/create-tag-legacy.yml) in the Hermes repo.
-
-Click the "Run Workflow" button. Run the workflow from `main`, input the React Native version you are releasing (e.g. 0.82.0, 0.82.1, etc), and the SHA of the head of your Hermes release branch.
-
-<figure>
-<img src="../assets/hermes_publish_tag.png" width="400" />
-</figure>
-
-Once the workflow is complete, it will create a new tag with the release you inputed and SHA. See [Hermes tags](https://github.com/facebook/hermes/tags)
-
-
-## Step 4: Bump the Hermes version on the React Native release branch
-
-Using the newly generated Hermes tag run the following script on the React Native release branch:
-
-```bash
-# Replace <the_hermes_tag> with the tag that will look like 'hermes-2022-07-20-RNv0.70.0-bc97c5399e0789c0a323f8e1431986e207a9e8ba'
-./packages/react-native/scripts/hermes/bump-hermes-version.js -t <the_hermes_tag>
-```
-
-Add and commit the extra file that got created at `packages/react-native/sdks/hermes/.hermesversion`. Now you can continue with the rest of your React Native release.
-
-```
-git add packages/react-native/sdks/.hermesvesion && git commit -m "Bump hermes version"
-```


### PR DESCRIPTION
Updated the Hermes release guide for React Native versions, including new steps for version bumping and tagging.