### PR TITLE
Fix Core dSYM Maven URLs in the release notes template

### DIFF
--- a/docs/guide-release-process.md
+++ b/docs/guide-release-process.md
@@ -394,8 +394,8 @@ ReactNativeDependencies dSYMs:
 - [Release](https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-dependencies-dSYM-release.tar.gz)
 
 ReactNative Core dSYMs:
-- [Debug](https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-core-debug.tar.gz)
-- [Release](https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-core-release.tar.gz)
+- [Debug](https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-core-dSYM-debug.tar.gz)
+- [Release](https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/$VERSION/react-native-artifacts-$VERSION-reactnative-core-dSYM-release.tar.gz)
 
 ---
 


### PR DESCRIPTION
## Summary

The GitHub release body template in `docs/guide-release-process.md` labeled the last section **ReactNative Core dSYMs**, but the Maven URLs omitted the `dSYM-` classifier.

That made the links download the prebuilt `React.xcframework` tarball (`reactnative-core-debug.tar.gz` / `reactnative-core-release.tar.gz`) instead of the actual dSYMs (`reactnative-core-dSYM-debug.tar.gz` / `reactnative-core-dSYM-release.tar.gz`).

Step 6 already `curl`s the correct `reactnative-core-dSYM-*.tar.gz` artifacts. This change makes the manual release-notes template match those URLs, and match Hermes / ReactNativeDependencies which already include `dSYM-`.

Companion generator fix: https://github.com/react/react-native/pull/58114

## Test Plan

- Compared the template URLs to the Step 6 Maven verification curls in the same doc.
- Compared the Core classifier to `ReactNativeCoreUtils.stable_tarball_url(..., dsyms = true)` in react-native (`reactnative-core-dSYM-<build_type>.tar.gz`).