### PR TITLE
Revise Hermes release guide for React Native 0.88

### DIFF
--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -9,10 +9,93 @@
 Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebook/hermes). You can give yourself permission via the Meta Internal OSS dashboard.
 
 See the guide you need, based on the React native release you are running:
-- [React Native >= 0.87](#for-react-native--087)
+- [React Native >= 0.88](#for-react-native--088)
+- [React Native == 0.87](#for-react-native--087)
 - [React Native 0.83 <= X < 0.87](#for-react-native-083--x--087)
 
-## For React Native >= 0.87
+## For React Native >= 0.88
+
+Starting from React Native 0.83, we need to have one tag for HermesV1.
+
+We decoupled the build of Hermes from the React Native repository and we can now consume Hermes binaries that are produced in the Hermes repository
+
+### Step 1: Cherry-pick
+
+> [!Important]
+> If you cutting a release candidate, skip this step
+
+1. Checkout the `260318099.0.0-stable` branch.
+2. Pick the relevant commits onto that branch. The pick requests should be from `static_h` and no other branch on Hermes.
+3. Push the picks to the remote branch.
+
+### Step 2: Build Hermes and Publish Tag
+
+Navigate to the [RN Build Hermes](https://github.com/facebook/hermes/actions/workflows/rn-build-hermes.yml) and run the workflow once.
+This workflow:
+- builds the Hermes artifacts;
+- publishes them on maven;
+- publishes the hermes-compiler to NPM;
+- publish the tag on GitHub
+
+The tag will be created as last step, and we need to wait for the whole process to end before React Native can start the Release.
+
+> [!Important]
+> If you are releasing a patch for Hermes V1 for the latest version of React Native, you also have to bump the patch number [`hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/260318099.0.0-stable/npm/hermes-compiler/package.json#L3) file from the `260318099.0.0-stable`
+
+1. Set the branch to the Hermes V1 release branch: `260318099.0.0-stable`
+2. Set the release type as `Release`
+3. Keep `Update latest-v1 (unchecked leaves the npm tag unchanged)` unticked
+
+### Step 3: Bump the Hermes version on the React Native release branch
+
+Using the newly generated Hermes tag run the following script on the React Native release branch:
+
+```bash
+# Replace <the_hermes_tag> with the tag that will look like 'hermes-2022-07-20-RNv0.70.0-bc97c5399e0789c0a323f8e1431986e207a9e8ba'
+./packages/react-native/scripts/hermes/bump-hermes-version.js -s <the_hermes_v1_tag>
+```
+
+An example of the invocation is:
+```
+./packages/react-native/scripts/hermes/bump-hermes-version.js -s hermes-v260318099.0.3
+```
+
+> [!Note]
+> The script also support the `-v` parameter to specify the Hermes V1 version.
+> When not passed, the script will check the latest version of hermes published on NPM and will prompt for confirmation.
+
+Add and commit the extra files that got created at:
+- packages/react-native/sdks/.hermesV1version
+and updated at:
+- packages/react-native/sdks/hermes-engine/version.properties
+- packages/react-native/package.json
+
+Now you can continue with the rest of your React Native release.
+
+```
+git add packages/react-native/sdks/.hermesvesion packages/react-native/sdks/.hermesv1vesion packages/react-native/sdks/hermes-engine/version.properties
+git commit -m "Bump hermes version"
+```
+
+### Step 4: Bump version on Hermes v1 release branch
+
+The `260318099.0.0-stable` should always track the next version that we are going to release.
+
+After the build started and the tag is generated, bump the hermes-compiler versions on those branches:
+
+From the `260318099.0.0-stable` branch
+1. Open the [`npm/hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/ddd708a85b164d1841c024973d0f6d3fad60a4c2/npm/hermes-compiler/package.json) file
+2. Bump the **patch** number by 1
+3. Commit and push.
+
+### Step 5: [Only for Branch Cut] Bump hermes versions on React Native `main` branch
+1. Go to the react-native repository
+2. Update the [`packages/react-native/sdks/hermes-engine/versions.properties` file]([url](https://github.com/facebook/react-native/blob/main/packages/react-native/sdks/hermes-engine/version.properties)) by bumping the `HERMES_V1_VERSION_NAME`
+This is an [example PR](https://github.com/facebook/react-native/pull/55042).
+
+---
+
+## For React Native == 0.87
 
 Starting from React Native 0.83, we need to have one tag for HermesV1.
 

--- a/docs/guide-hermes-release.md
+++ b/docs/guide-hermes-release.md
@@ -9,93 +9,13 @@
 Prerequisites: You'll need access to the [Hermes repo](https://github.com/facebook/hermes). You can give yourself permission via the Meta Internal OSS dashboard.
 
 See the guide you need, based on the React native release you are running:
-- [React Native >= 0.88](#for-react-native--088)
-- [React Native == 0.87](#for-react-native--087)
+- [React Native >= 0.87](#for-react-native--087)
 - [React Native 0.83 <= X < 0.87](#for-react-native-083--x--087)
 
-## For React Native >= 0.88
-
-Starting from React Native 0.83, we need to have one tag for HermesV1.
-
-We decoupled the build of Hermes from the React Native repository and we can now consume Hermes binaries that are produced in the Hermes repository
-
-### Step 1: Cherry-pick
+## For React Native >= 0.87
 
 > [!Important]
-> If you cutting a release candidate, skip this step
-
-1. Checkout the `260318099.0.0-stable` branch.
-2. Pick the relevant commits onto that branch. The pick requests should be from `static_h` and no other branch on Hermes.
-3. Push the picks to the remote branch.
-
-### Step 2: Build Hermes and Publish Tag
-
-Navigate to the [RN Build Hermes](https://github.com/facebook/hermes/actions/workflows/rn-build-hermes.yml) and run the workflow once.
-This workflow:
-- builds the Hermes artifacts;
-- publishes them on maven;
-- publishes the hermes-compiler to NPM;
-- publish the tag on GitHub
-
-The tag will be created as last step, and we need to wait for the whole process to end before React Native can start the Release.
-
-> [!Important]
-> If you are releasing a patch for Hermes V1 for the latest version of React Native, you also have to bump the patch number [`hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/260318099.0.0-stable/npm/hermes-compiler/package.json#L3) file from the `260318099.0.0-stable`
-
-1. Set the branch to the Hermes V1 release branch: `260318099.0.0-stable`
-2. Set the release type as `Release`
-3. Keep `Update latest-v1 (unchecked leaves the npm tag unchanged)` unticked
-
-### Step 3: Bump the Hermes version on the React Native release branch
-
-Using the newly generated Hermes tag run the following script on the React Native release branch:
-
-```bash
-# Replace <the_hermes_tag> with the tag that will look like 'hermes-2022-07-20-RNv0.70.0-bc97c5399e0789c0a323f8e1431986e207a9e8ba'
-./packages/react-native/scripts/hermes/bump-hermes-version.js -s <the_hermes_v1_tag>
-```
-
-An example of the invocation is:
-```
-./packages/react-native/scripts/hermes/bump-hermes-version.js -s hermes-v260318099.0.3
-```
-
-> [!Note]
-> The script also support the `-v` parameter to specify the Hermes V1 version.
-> When not passed, the script will check the latest version of hermes published on NPM and will prompt for confirmation.
-
-Add and commit the extra files that got created at:
-- packages/react-native/sdks/.hermesV1version
-and updated at:
-- packages/react-native/sdks/hermes-engine/version.properties
-- packages/react-native/package.json
-
-Now you can continue with the rest of your React Native release.
-
-```
-git add packages/react-native/sdks/.hermesvesion packages/react-native/sdks/.hermesv1vesion packages/react-native/sdks/hermes-engine/version.properties
-git commit -m "Bump hermes version"
-```
-
-### Step 4: Bump version on Hermes v1 release branch
-
-The `260318099.0.0-stable` should always track the next version that we are going to release.
-
-After the build started and the tag is generated, bump the hermes-compiler versions on those branches:
-
-From the `260318099.0.0-stable` branch
-1. Open the [`npm/hermes-compiler/package.json`](https://github.com/facebook/hermes/blob/ddd708a85b164d1841c024973d0f6d3fad60a4c2/npm/hermes-compiler/package.json) file
-2. Bump the **patch** number by 1
-3. Commit and push.
-
-### Step 5: [Only for Branch Cut] Bump hermes versions on React Native `main` branch
-1. Go to the react-native repository
-2. Update the [`packages/react-native/sdks/hermes-engine/versions.properties` file]([url](https://github.com/facebook/react-native/blob/main/packages/react-native/sdks/hermes-engine/version.properties)) by bumping the `HERMES_V1_VERSION_NAME`
-This is an [example PR](https://github.com/facebook/react-native/pull/55042).
-
----
-
-## For React Native == 0.87
+> For **versions >= 0.88**, use branch `260318099.0.0-stable`, rather than `250829098.0.0-stable`
 
 Starting from React Native 0.83, we need to have one tag for HermesV1.
 


### PR DESCRIPTION
Updated the guide for Hermes release process to include React Native 0.88 and detailed steps for version bumping.